### PR TITLE
Ensure Notebook Files are Downloaded Instead of Opened in Browser

### DIFF
--- a/src/download_link_replacer/events.py
+++ b/src/download_link_replacer/events.py
@@ -72,6 +72,7 @@ def _add_link_to_context(link: LinkEntry, dl_buttons: list[dict[str, str]]):
         for button in dl_buttons:
             if button["type"] == "link" and button["label"] == "download-source-button":
                 button["url"] = link.url
+                button["download"] = link.url.split("/")[-1]
                 if link.text is not None:
                     button["text"] = link.text
                 break
@@ -89,6 +90,7 @@ def _add_link_to_context(link: LinkEntry, dl_buttons: list[dict[str, str]]):
                 "tooltip": "Download",
                 "icon": "fas fa-file",
                 "label": "download-button",
+                "download": link.url.split("/")[-1],
             }
         )
 


### PR DESCRIPTION
This pull request modifies `_add_link_to_context` to ensure that files, such as Jupyter notebooks (.ipynb), are downloaded instead of being opened in the browser. The change leverages the download attribute in the generated link, which forces the browser to download the file with the appropriate filename.

## Changes Made
1. Added download Attribute:
    - The download attribute is now included in the link dictionary for both default and new download buttons.
    - The value of the download attribute is set to the filename extracted from the URL `link.url.split("/")[-1]`
2. Updated `_add_link_to_context` 
    - Ensured that the download attribute is added when replacing the default button or appending a new button.

## Why This Change?
When users click on links to .ipynb files, browsers often open the file instead of downloading it. This behavior is not ideal for users who expect to download the file for offline use. By adding the download attribute, we ensure a consistent and user-friendly experience.

## Testing
- [ ] Verified that .ipynb files are downloaded with the correct filename.
- [ ] Confirmed that other  file types also respect the download behavior.
- [ ] Ensured no regressions in the behavior of other download buttons.

## Example

For a link with the URL https://example.com/files/notebook.ipynb, the generated button will now include:
```html
<a href="https://example.com/files/notebook.ipynb" download="notebook.ipynb">Download</a>
```