### PR TITLE
Switch to importlib.metadata for version retrieval

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,8 @@ authors = [
 description = "A tool to replace download links in Jupyter books."
 readme = "README.md"
 dependencies = [
-    "sphinx"
+    "sphinx",
+    "importlib"
 ]
 requires-python = ">=3.9"
 

--- a/src/download_link_replacer/utils.py
+++ b/src/download_link_replacer/utils.py
@@ -1,7 +1,7 @@
-from pkg_resources import get_distribution
+from importlib.metadata import version
 from sphinx.util import logging
 
-VERSION = get_distribution("download_link_replacer").version
+VERSION = version("download_link_replacer")
 
 SPHINX_LOGGER = logging.getLogger(__name__)
 ENV_PROPERTY_NAME = "download_link_replacements"


### PR DESCRIPTION
This pull request updates the way the package version is retrieved and adds a new dependency to the project. The main focus is on modernizing the version lookup and ensuring the correct dependencies are listed.

Dependency updates:

* Added `importlib` to the dependencies in `pyproject.toml` to support modern version retrieval.

Code modernization:

* Updated `src/download_link_replacer/utils.py` to use `importlib.metadata.version` instead of `pkg_resources.get_distribution` for fetching the package version.