### PR TITLE
fix _config instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,11 @@ download-link-replacer
 
 **Step 3: Enable in `_config.yml`**
 
-In your `_config.yml` file, add the extension to the list of Sphinx extra extensions:
+In your `_config.yml` file, add the extension to the list of Sphinx extra extensions (_note the underscores!_):
 ```
 sphinx: 
     extra_extensions:
-        - download-link-replacer
+        - download_link_replacer
 ```
 
 ## Contribute


### PR DESCRIPTION
Underscores `_` should be used in _config, not dashes `-`.

Confirmed here: https://github.com/prob-design/risk-reliability/commit/3a68df7cf1aeb8bcad5b0bd34f76825585f03e11