### PR TITLE
update manual docs in addition to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,11 @@ download-link-replacer
 
 **Step 3: Enable in `_config.yml`**
 
-In your `_config.yml` file, add the extension to the list of Sphinx extra extensions:
+In your `_config.yml` file, add the extension to the list of Sphinx extra extensions (_note the underscores!_):
 ```
 sphinx: 
     extra_extensions:
-        - download-link-replacer
+        - download_link_replacer
 ```
 
 ## Contribute


### PR DESCRIPTION
This just sends the commit to `manual_docs` as well. Identical to PR #6 